### PR TITLE
Space items in header equally & Increase contrast on button:hover state

### DIFF
--- a/_scss/_base.scss
+++ b/_scss/_base.scss
@@ -3,54 +3,60 @@
  */
 
 body {
-    background-color: $color-white;
+  background-color: $color-white;
 }
 
-section, header {
-    padding-left: $full-width-paddingX;
-    padding-right: $full-width-paddingX;
+section,
+header {
+  padding-left: $full-width-paddingX;
+  padding-right: $full-width-paddingX;
 
-    main {
-        width: $main-width;
-        // !Important.  Home page scrolls horz. without this width constraint (affected by SVG <img> issues)
-        max-width: $media-size-max-width;;
-    }
+  main {
+    width: $main-width;
+    // !Important.  Home page scrolls horz. without this width constraint (affected by SVG <img> issues)
+    max-width: $media-size-max-width;
+  }
 }
 
-section, header, footer {
-    main {
-        position: relative;
-        margin: auto;
-    }
+section,
+header,
+footer {
+  main {
+    position: relative;
+    margin: auto;
+  }
 }
 
 section {
-    position: relative;
-    background-color: $color-white;
+  position: relative;
+  background-color: $color-white;
 }
 
 footer {
-    width: 100%;
-    background-color: $color-blue-dark;
-    padding: $whisk-footer-base-padding-base
+  width: 100%;
+  background-color: $color-blue-dark;
+  padding: $whisk-footer-base-padding-base;
 }
 
 // Note: options: white-space: normal|nowrap|pre|pre-line|pre-wrap
 // Note: non-std. options:  white-space: -moz-pre-wrap | -o-pre-wrap;
 pre {
-    white-space: pre;
-    display: inline;
-    margin: 0px;
+  white-space: pre;
+  display: inline;
+  margin: 0px;
 }
 
 .header {
-  display: table;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  flex-flow: row wrap;
   background-color: $color-header-bg;
   position: fixed;
   z-index: 8888;
   top: 0;
   width: 100%;
-  height: $header-height;
+  min-height: $header-height;
   padding-bottom: 20px;
 
   // Assure that menu items have white foreground and proper spacing
@@ -70,178 +76,172 @@ pre {
 // Note: the use if !important may be superfluous
 // Note: use of a fixed .PNG seems to be more reliable than .SVG
 // where different browsers tend to stretch SVG despite layout properties
+
 .header-section-logo {
-    display: table-cell;
-    position: relative;
-    width: $logo-width !important;
-    height: $logo-height !important;
-    border: 0px;
-    padding: 0px;
-    background-color: $color-header-bg-section-logo;
-    background-image: url(/images/apache-openwhisk.png);
-    background-size: $logo-width $logo-height !important;
-    background-repeat: no-repeat;
-    border: none !important;
-    background-position: 50% 50%;
+  width: $logo-width !important;
+  height: $logo-height !important;
+  border: 0px;
+  padding: 0px;
+  background-color: $color-header-bg-section-logo;
+  background-image: url(/images/apache-openwhisk.png);
+  background-size: $logo-width $logo-height !important;
+  background-repeat: no-repeat;
+  border: none !important;
+  background-position: 50% 50%;
 }
 
 .header-section-text-links {
-    display: table-row-group;
-    background: $color-header-bg-section-menu-text;
-    width: 33%;
-    min-width: 280px;
-    color: white;
-    text-align: center;
-    vertical-align: middle;
+  background: $color-header-bg-section-menu-text;
+  min-width: 280px;
+  color: white;
+  text-align: center;
 }
 
 // TODO: explore min-width had no effect for some reason...
 .header-section-social-icons {
-    display: table-footer-group;
-    background-color: $color-header-bg-section-menu-icons;
-    width: 33%;
-    vertical-align: middle;
+  background-color: $color-header-bg-section-menu-icons;
 }
 
 // TODO: change row (div) height to have no padding/margin top and bottom
 .header-row-text-links {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: center;
-    font-size: 14px;
-    font-weight: 500;
-    letter-spacing: 0.5px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
 }
 
 .header-row-social-icons {
-    display: flex;
-    flex-direction: row-reverse;
-    justify-content: center;
-    padding-left: 10px;
-    padding-right: 10px;
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: center;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 .header-button-icon {
-    flex: 0 0 auto;
-    background-color: $color-header-icon-bg;
-    border: 1px solid $color-header-icon-border;
-    border-radius: 4px;
-    align: center;
-    height: 36px;
-    width: 36px;
-    margin-right: 4px;
+  flex: 0 0 auto;
+  background-color: $color-header-icon-bg;
+  border: 1px solid $color-header-icon-border;
+  border-radius: 4px;
+  align: center;
+  height: 36px;
+  width: 36px;
+  margin-right: 4px;
 }
 
 .header-text-link {
-    flex: 0 0 auto;
-    background-color: $color-header-icon-bg;
-    margin: 3px;
+  flex: 0 0 auto;
+  background-color: $color-header-icon-bg;
+  margin: 3px;
 }
 
 .header-icon-image {
-   background: $color-header-icon-bg-image;
-   width: 26px;
-   padding: 0px;
+  background: $color-header-icon-bg-image;
+  width: 26px;
+  padding: 0px;
 }
 
 // TODO: move sizes to variables.
 .terminal {
-    background: $color-terminal-bg;
-    color: $color-terminal-fg;
-    border: 1px solid $color-terminal-border;
-    font-family: $font-family-code;
-    font-weight: 300;
-    font-size: 14px;
-    line-height: 140%;
-    // top right bottom left
-    padding: 4px 4px 4px 8px;
-    width: 700px;
-    margin-bottom: 10px;
+  background: $color-terminal-bg;
+  color: $color-terminal-fg;
+  border: 1px solid $color-terminal-border;
+  font-family: $font-family-code;
+  font-weight: 300;
+  font-size: 14px;
+  line-height: 140%;
+  // top right bottom left
+  padding: 4px 4px 4px 8px;
+  width: 700px;
+  margin-bottom: 10px;
 }
 
 // Header is only shown on the "home" page
 // TODO: add padding to title/tag line for small media
 #whiskHeader {
-    background-color: $color-blue-dark;
+  background-color: $color-blue-dark;
+  color: $color-white;
+  text-align: center;
+  padding-top: $whisk-header-base-padding-top;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-bottom: 10px;
+  margin-bottom: $whisk-nodes-padding-base-Y;
+
+  h1 {
+    font-size: $header-base-h1-font-size;
+    font-weight: $header-base-h1-font-weight;
+    font-style: $header-base-h1-font-style;
+    line-height: $header-base-h1-line-height;
+    margin-bottom: 12px;
+  }
+  h5 {
+    font-size: $header-base-h5-font-size;
+    font-weight: $header-base-h5-font-weight;
+    font-style: $header-base-h5-font-style;
+    line-height: $header-base-h5-line-height;
+    margin-bottom: 4px;
+  }
+
+  h1,
+  h5 {
     color: $color-white;
-    text-align: center;
-    padding-top: $whisk-header-base-padding-top;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-bottom: 10px;
-    margin-bottom: $whisk-nodes-padding-base-Y;
-
-    h1 {
-        font-size: $header-base-h1-font-size;
-        font-weight: $header-base-h1-font-weight;
-        font-style: $header-base-h1-font-style;
-        line-height: $header-base-h1-line-height;
-        margin-bottom: 12px;
-    }
-    h5 {
-        font-size: $header-base-h5-font-size;
-        font-weight: $header-base-h5-font-weight;
-        font-style: $header-base-h5-font-style;
-        line-height: $header-base-h5-line-height;
-        margin-bottom: 4px;
-    }
-
-    h1, h5 {
-        color: $color-white;
-    }
+  }
 }
 
 #whiskNodes {
-    // Note: pad only the bottom for each "node" (so we do not double up)
-    padding-bottom: $whisk-nodes-padding-base-Y;
-    padding-left: $whisk-nodes-padding-base-X;
-    padding-right: $whisk-nodes-padding-base-X;
+  // Note: pad only the bottom for each "node" (so we do not double up)
+  padding-bottom: $whisk-nodes-padding-base-Y;
+  padding-left: $whisk-nodes-padding-base-X;
+  padding-right: $whisk-nodes-padding-base-X;
 
-    main {
-        display: table;
-        background: $color-bg-base-main;
-        margin-bottom: $whisk-nodes-padding-base-Y;
+  main {
+    display: table;
+    background: $color-bg-base-main;
+    margin-bottom: $whisk-nodes-padding-base-Y;
+  }
+  .content {
+    background: $color-bg-base-content;
+    // Provide for space around content's text
+    padding: $whisk-nodes-main-content-padding-base;
+    // TODO: ????
+    height: 100%;
+
+    // Provide a space between image and content when vertical
+    margin-top: 20px;
+  }
+  .image-wrapper {
+    background: $color-bg-base-image-wrapper;
+    display: table-header-group;
+
+    // NOTE: margin ONLY works in horz. layout and has no impact in vert. layout
+    // margin: (top right bottom left)
+    margin: $main-image-wrapper-margin-base;
+
+    // NOTE: SVG files and the <img> tags do not work well together
+    // Important! without this style, the image will not stretch and display properly
+    img {
+      background: $color-bg-base-img;
+      display: block;
+      width: 100%;
+      height: 100%;
     }
-    .content {
-        background: $color-bg-base-content;
-        // Provide for space around content's text
-        padding: $whisk-nodes-main-content-padding-base;
-        // TODO: ????
-        height: 100%;
+  }
 
-        // Provide a space between image and content when vertical
-        margin-top: 20px;
-    }
-    .image-wrapper {
-        background: $color-bg-base-image-wrapper;
-        display: table-header-group;
-
-        // NOTE: margin ONLY works in horz. layout and has no impact in vert. layout
-        // margin: (top right bottom left)
-        margin: $main-image-wrapper-margin-base;
-
-        // NOTE: SVG files and the <img> tags do not work well together
-        // Important! without this style, the image will not stretch and display properly
-        img {
-            background: $color-bg-base-img;
-            display: block;
-            width: 100%;
-            height: 100%;
-        }
-    }
-
-    h3 {
-        margin-bottom: $whisk-nodes-h3-margin-bottom;
-    }
+  h3 {
+    margin-bottom: $whisk-nodes-h3-margin-bottom;
+  }
 }
 
 #doc {
-    position: relative;
-    overflow: hidden;
-    // TODO: evaluate this value's effect
-    padding-top: 10px;
-    text-align: left;
+  position: relative;
+  overflow: hidden;
+  // TODO: evaluate this value's effect
+  padding-top: 10px;
+  text-align: left;
 }
 
 /*
@@ -249,22 +249,22 @@ pre {
  */
 
 .flow-columns {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    margin-bottom: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin-bottom: 10px;
 }
 
 .flow-item-container {
-    width: 260px;
-    background: $color-blue-gray-light;
-    margin: 10px;
+  width: 260px;
+  background: $color-blue-gray-light;
+  margin: 10px;
 }
 
 .flow-item-image {
-    border-image-width: 0px;
-    max-width: 240px;
-    width: 240px;
+  border-image-width: 0px;
+  max-width: 240px;
+  width: 240px;
 }
 
 /*
@@ -272,24 +272,24 @@ pre {
  */
 
 .collapsible-toggle {
-    color: $color-menu-collapsible-fg;
-    background-color: $color-menu-collapsible-bg;
-    border: 1px solid $color-menuitem-collapsible-border;
-    cursor: pointer;  // finger shown to let ppl know you can click it
-    width: 100%;
-    outline: none;
-    padding-left: 10px;
+  color: $color-menu-collapsible-fg;
+  background-color: $color-menu-collapsible-bg;
+  border: 1px solid $color-menuitem-collapsible-border;
+  cursor: pointer; // finger shown to let ppl know you can click it
+  width: 100%;
+  outline: none;
+  padding-left: 10px;
 }
 
 .collapsible-toggle:hover {
-    background-color: $color-menu-collapsible-hover-bg;
+  background-color: $color-menu-collapsible-hover-bg;
 }
 
 .collapse-content {
-    padding: 0 18px;
-    display: none;
-    overflow: hidden;
-    background-color: white;
+  padding: 0 18px;
+  display: none;
+  overflow: hidden;
+  background-color: white;
 }
 
 /*
@@ -299,84 +299,90 @@ pre {
 // Need to create custom anchors that are aware of our fixed header
 // (i.e., position below it on click)
 a.indexable {
-    display: block;
-    position: relative;
-    // TODO: make a variable
-    top: -100px;
-    visibility: hidden;
+  display: block;
+  position: relative;
+  // TODO: make a variable
+  top: -100px;
+  visibility: hidden;
 }
 
 #whiskIndexedLayout {
-    display: table;
-    padding-top: $whisk-header-base-padding-top;
+  display: table;
+  padding-top: $whisk-header-base-padding-top;
 
-    #whiskIndex {
-        vertical-align: top;
-        // position menu relative to header
-        display: float;
-        position: fixed;
-        top: $index-menu-top-offset;
-        left: $index-menu-left-offset;
-        width: $index-menu-width;
-        border: $index-border;
-        z-index: 6888;
-    }
+  #whiskIndex {
+    vertical-align: top;
+    // position menu relative to header
+    display: float;
+    position: fixed;
+    top: $index-menu-top-offset;
+    left: $index-menu-left-offset;
+    width: $index-menu-width;
+    border: $index-border;
+    z-index: 6888;
+  }
 
-    #whiskNodes {
-       display: table-cell;
-       // Note: we do NOT make left padding for Index in for the 'base' media size (width too small)
-    }
+  #whiskNodes {
+    display: table-cell;
+    // Note: we do NOT make left padding for Index in for the 'base' media size (width too small)
+  }
 }
 
 #whiskIndex {
-    // Note: we will turn this off for small/base media, allow other profiles to turn on.
-    display: none;
-    background-color: $color-index-bg;
+  // Note: we will turn this off for small/base media, allow other profiles to turn on.
+  display: none;
+  background-color: $color-index-bg;
+  color: $color-index-fg;
+  width: $index-menu-width;
+  // Pad the overall index <ul> (and not all the nested <ul>s)
+  padding: 10px;
+
+  ul {
+    background-color: $color-index-list-bg;
+    font-size: $index-menu-font-size;
+    font-weight: 500;
+
+    //list-style-type: square;
+    //list-style-position: inside;
+    //list-style-image: url('abc.png')
+    //list-style: square inside url("abc.png");
+    list-style-type: none;
+    list-style-position: inside;
+
+    // Override <ul> defaults:
+    // default margin: 16px (top and bottom)
+    // TODO: make variables
+    margin: 0px;
+    padding-left: 10px;
+    padding-right: 0px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+  }
+
+  li {
+    background-color: $color-index-item-bg;
+    border: $index-item-border;
+    font-size: $index-menu-font-size;
+    font-weight: 500;
+    // TODO: make variables
+    padding-left: 4px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    margin-left: 4px;
+  }
+
+  a {
     color: $color-index-fg;
-    width: $index-menu-width;
-    // Pad the overall index <ul> (and not all the nested <ul>s)
-    padding: 10px;
+    text-decoration: none;
+  }
 
-    ul {
-        background-color: $color-index-list-bg;
-        font-size: $index-menu-font-size;
-        font-weight: 500;
-
-        //list-style-type: square;
-        //list-style-position: inside;
-        //list-style-image: url('abc.png')
-        //list-style: square inside url("abc.png");
-        list-style-type: none;
-        list-style-position: inside;
-
-        // Override <ul> defaults:
-        // default margin: 16px (top and bottom)
-        // TODO: make variables
-        margin: 0px;
-        padding-left: 10px;
-        padding-right: 0px;
-        padding-top: 2px;
-        padding-bottom: 2px;
-    }
-
-    li {
-        background-color: $color-index-item-bg;
-        border: $index-item-border;
-        font-size: $index-menu-font-size;
-        font-weight: 500;
-        // TODO: make variables
-        padding-left: 4px;
-        padding-top: 2px;
-        padding-bottom: 2px;
-        margin-left: 4px;
-    }
-
-    a {
-        color: $color-index-fg;
-        text-decoration: none;
-    }
-
-    a:visited {color:$color-index-fg;}
-    a:hover {color: $color-index-fg;}
-    a:active {color: $color-index-fg;}
+  a:visited {
+    color: $color-index-fg;
+  }
+  a:hover {
+    color: $color-index-fg;
+  }
+  a:active {
+    color: $color-index-fg;
+  }
 }

--- a/_scss/_skin.scss
+++ b/_scss/_skin.scss
@@ -1,104 +1,120 @@
-
 * {
-    box-sizing: border-box;
-    font-family: $font-family-default;
-    background: none;
-    border: 0
+  box-sizing: border-box;
+  font-family: $font-family-default;
+  background: none;
+  border: 0;
 }
 
 body {
-    font-family: $font-family-default;
+  font-family: $font-family-default;
 }
 
 strong {
-    //color: $color-blue-dark;
+  //color: $color-blue-dark;
 }
 
-h1, h2, h3, h4, h5 {
-    font-weight: $font-weight-bold;
-    //color: $color-blue-dark;
-    margin: 0;
+h1,
+h2,
+h3,
+h4,
+h5 {
+  font-weight: $font-weight-bold;
+  //color: $color-blue-dark;
+  margin: 0;
 }
 
 h1 {
-    font-size: $h1-font-size;
-    line-height: $h1-line-height;
+  font-size: $h1-font-size;
+  line-height: $h1-line-height;
 }
 
 h2 {
-    font-size: $h2-font-size;
-    line-height: $h2-line-height;
+  font-size: $h2-font-size;
+  line-height: $h2-line-height;
 }
 
 h3 {
-    font-size: $h3-font-size;
-    line-height: $h3-line-height;
+  font-size: $h3-font-size;
+  line-height: $h3-line-height;
 }
 
 h4 {
-    font-size: $h4-font-size;
-    line-height: $h4-line-height;
+  font-size: $h4-font-size;
+  line-height: $h4-line-height;
 }
 
 h5 {
-    font-size: $h5-font-size;
-    line-height: $h5-line-height;
+  font-size: $h5-font-size;
+  line-height: $h5-line-height;
 }
 
-p, ul, ol, li {
-    font-size: $p-font-size;
-    font-weight: $p-font-weight;
-    line-height: $p-line-height;
-    color: $color-blue-dark-text;
+p,
+ul,
+ol,
+li {
+  font-size: $p-font-size;
+  font-weight: $p-font-weight;
+  line-height: $p-line-height;
+  color: $color-blue-dark-text;
 }
 
 .light-text {
-    clear: both;
-    color: $color-fg-base-light-text;
-    // TODO: make vars.
-    font-size: 11px;
-    font-weight: 300;
-    line-height: 18px;
+  clear: both;
+  color: $color-fg-base-light-text;
+  // TODO: make vars.
+  font-size: 11px;
+  font-weight: 300;
+  line-height: 18px;
 }
 
-a {color: $color-anchors }
-a:visited { color: $color-anchors; }
-a:hover {color: $color-anchors;}
-a:active {color: $color-anchors;}
+a {
+  color: $color-anchors;
+}
+a:visited {
+  color: $color-anchors;
+}
+a:hover {
+  color: $color-anchors;
+}
+a:active {
+  color: $color-anchors;
+}
 
 a.button {
-    color: white;
+  color: white;
 }
 
 .button {
-    color: $color-white;
-    background-color: $color-blue-dark;
-    border: solid 1px #d0d0d0;
-    border-bottom: solid 3px #b2b1b1;
-    border-radius: 6px;
-    padding: 0 20px;
-    box-shadow: inset 0 0 0 1px #f5f5f5;
-    display: inline-block;
-    font-size: 13px;
-    font-family: $font-family-default;
-    font-weight: 300;
-    line-height: 40px;
-    position: relative;
-    text-align: center;
-    text-decoration: none;
-    text-shadow: 0 1px 0 #fafafa;
+  color: $color-white;
+  background-color: $color-blue-dark;
+  border: solid 1px #d0d0d0;
+  border-bottom: solid 3px #b2b1b1;
+  border-radius: 6px;
+  padding: 0 20px;
+  box-shadow: inset 0 0 0 1px #f5f5f5;
+  display: inline-block;
+  font-size: 13px;
+  font-family: $font-family-default;
+  font-weight: 300;
+  line-height: 40px;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-shadow: 0 1px 0 #fafafa;
 }
 
 .button:hover {
-    background: $color-blue-hover;
-    border: solid 1px #c2c2c2;
-    border-bottom: solid 3px #b2b1b1;
-    box-shadow: inset 0 0 0 1px #efefef;
+  background: $color-blue-hover;
+  border: solid 1px #c2c2c2;
+  border-bottom: solid 3px #b2b1b1;
+  box-shadow: inset 0 0 0 1px #efefef;
+  color: $color-blue-dark;
+  text-shadow: 0 1px 0 rgba($color-blue-dark, 0.6);
 }
 
 .button:active {
-    background: #dfdfdf;
-    border: solid 1px #959595;
-    box-shadow: inset 0 10px 15px 0 #c4c4c4;
-    top:2px;
+  background: #dfdfdf;
+  border: solid 1px #959595;
+  box-shadow: inset 0 10px 15px 0 #c4c4c4;
+  top: 2px;
 }

--- a/_scss/_tablet.scss
+++ b/_scss/_tablet.scss
@@ -1,92 +1,89 @@
 @media screen and (min-width: $media-size-tablet-start) {
-    .header {
-        // TODO: make variables
-        height: $header-height;
-        padding-bottom: 0px;
-        background-position: 10px center;
-        background-size: contain;
-    }
-    .header-section-logo {
-        display: block;
-    }
-    .header-section-text-links {
-        display: table-cell;
-    }
+  .header {
+    // TODO: make variables
+    padding-bottom: 0px;
+    background-position: 10px center;
+    background-size: contain;
+  }
+  .header-section-logo {
+    display: block;
+  }
+  .header-section-text-links {
+    display: table-cell;
+  }
 
-    .header-section-social-icons {
-        display: table-cell;
+  .header-section-social-icons {
+    display: table-cell;
+  }
+
+  footer {
+    padding: $whisk-footer-base-padding-tablet;
+  }
+
+  #whiskHeader {
+    padding-top: $whisk-header-tablet-padding-top;
+    h1 {
+      font-size: $header-tablet-h1-font-size;
+      font-weight: $header-tablet-h1-font-weight;
+      font-style: $header-tablet-h1-font-style;
+      line-height: $header-tablet-h1-line-height;
     }
-
-    footer {
-        padding: $whisk-footer-base-padding-tablet;
+    h5 {
+      font-size: $header-tablet-h5-font-size;
+      font-weight: $header-tablet-h5-font-weight;
+      font-style: $header-tablet-h5-font-style;
+      line-height: $header-tablet-h5-line-height;
     }
+  }
 
-    #whiskHeader {
-        padding-top: $whisk-header-tablet-padding-top;
-        h1 {
-            font-size: $header-tablet-h1-font-size;
-            font-weight: $header-tablet-h1-font-weight;
-            font-style: $header-tablet-h1-font-style;
-            line-height: $header-tablet-h1-line-height;
-        }
-        h5 {
-            font-size: $header-tablet-h5-font-size;
-            font-weight: $header-tablet-h5-font-weight;
-            font-style: $header-tablet-h5-font-style;
-            line-height: $header-tablet-h5-line-height;
-        }
-
-    }
-
-    // "Turn on" left index in this profile, as we have width to support it
-    #whiskIndexedLayout {
-        padding-top: $whisk-header-tablet-padding-top;
-        // Show the index area
-        #whiskIndex {
-            display: block;
-        }
-
-        // Make room on left for the Index
-        #whiskNodes {
-            display: table-cell;
-            // NOTE: margin does not work here, must use left padding
-            padding-left: $index-menu-width;
-        }
+  // "Turn on" left index in this profile, as we have width to support it
+  #whiskIndexedLayout {
+    padding-top: $whisk-header-tablet-padding-top;
+    // Show the index area
+    #whiskIndex {
+      display: block;
     }
 
+    // Make room on left for the Index
     #whiskNodes {
-
-        padding-left: $whisk-nodes-padding-tablet-X;
-        padding-right: $whisk-nodes-padding-tablet-X;
-
-        main {
-            clear: both;
-            display: table;
-            background: $color-bg-tablet-main;
-            position: relative;
-
-            .content {
-                display: table-cell;
-                vertical-align: top;
-                position: relative;
-                width: $main-content-width-tablet;
-                padding: $whisk-nodes-main-content-padding-tablet;
-
-                // No top margin needed when content & image-wrapper are horz.
-                margin-top: 0px;
-            }
-            .image-wrapper {
-                // Alter to a 'block' display to get side-by-side layout
-                display: block;
-                position: relative;
-
-                // Note: we have a border in side-by-side layout, but do not in vertical layout.
-                border: $color-bg-tablet-image-wrapper-border;
-            }
-        }
-        h3 {
-            text-align: left;
-            margin-bottom: 18px;
-        }
+      display: table-cell;
+      // NOTE: margin does not work here, must use left padding
+      padding-left: $index-menu-width;
     }
+  }
+
+  #whiskNodes {
+    padding-left: $whisk-nodes-padding-tablet-X;
+    padding-right: $whisk-nodes-padding-tablet-X;
+
+    main {
+      clear: both;
+      display: table;
+      background: $color-bg-tablet-main;
+      position: relative;
+
+      .content {
+        display: table-cell;
+        vertical-align: top;
+        position: relative;
+        width: $main-content-width-tablet;
+        padding: $whisk-nodes-main-content-padding-tablet;
+
+        // No top margin needed when content & image-wrapper are horz.
+        margin-top: 0px;
+      }
+      .image-wrapper {
+        // Alter to a 'block' display to get side-by-side layout
+        display: block;
+        position: relative;
+
+        // Note: we have a border in side-by-side layout, but do not in vertical layout.
+        border: $color-bg-tablet-image-wrapper-border;
+      }
+    }
+    h3 {
+      text-align: left;
+      margin-bottom: 18px;
+    }
+  }
 }


### PR DESCRIPTION
Space items equally in the header. This includes logo that was originally always fixed in the top left corner, no matter how big your monitor is.

Example of what it looks like on multiple resolutions:

![image](https://user-images.githubusercontent.com/4106/43615650-ac6b05ea-9686-11e8-9802-c89c8aeb81b2.png)

![image](https://user-images.githubusercontent.com/4106/43615659-b72e30b0-9686-11e8-9c78-14541481ca14.png)

![image](https://user-images.githubusercontent.com/4106/43615661-bb57bddc-9686-11e8-99a8-8e9128ebd969.png)

This pull request also increases the contrast on the buttons when hovering over them (otherwise it was white text on a light grey background).

![apache openwhisk is a serverless open source cloud platform 2018-08-02 19-04-26](https://user-images.githubusercontent.com/4106/43615718-046b36fc-9687-11e8-8c60-c3ac9a113cb7.png)
